### PR TITLE
remove console.log from __composeUserString function

### DIFF
--- a/lib/MimeMessage.js
+++ b/lib/MimeMessage.js
@@ -114,7 +114,6 @@ class MimeMessage {
 
     for (var i = 0; i < users.length; i++) {
       const user = users[i]
-      console.log(user)
       if (user === '') {
         // Skip empty users
       } else if (user && user !== undefined) {


### PR DESCRIPTION
I'm using the package and I believe that this console.log was left here my mistake. Every time we compose an email, the user is printed in console.